### PR TITLE
Enable CORS

### DIFF
--- a/peer-review-service.cabal
+++ b/peer-review-service.cabal
@@ -43,6 +43,7 @@ library
                      , vector >= 0.10
                      , bytestring >= 0.10
                      , http-types >= 0.8
+                     , wai-cors >= 0.2.3
   default-language:    Haskell2010
 
 executable peer-review-service-exe
@@ -72,6 +73,7 @@ test-suite peer-review-service-test
                      , hspec-wai-json
                      , Spock
                      , wai
+                     , wai-cors
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/PeerReview/Web/Server.hs
+++ b/src/PeerReview/Web/Server.hs
@@ -4,6 +4,7 @@ module PeerReview.Web.Server
     , service -- Exposed for testing.
     ) where
 
+import           Network.Wai.Middleware.Cors
 import           Network.Wai.Middleware.RequestLogger
 import           Web.Spock.Safe
 
@@ -22,7 +23,9 @@ runServer conf env = do
 
 -- Middlewares for the application.
 appMiddleware :: WebApp ()
-appMiddleware = middleware logStdout
+appMiddleware = do
+    middleware logStdout
+    middleware simpleCors
 
 -- Combine different routes for the api.
 apiRoutes :: WebApp ()


### PR DESCRIPTION
Enables CORS to make JS-client work. Allows requests from all origins.

Closes #21
